### PR TITLE
Improve puyo board appearance

### DIFF
--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -92,7 +92,13 @@ const PuyoBoard: Component<Props> = (props) => {
                 } as any}
                 class={`${cv !== null ? colors[cv] : 'bg-gray-900'} puyo ${dist > 0 ? 'animate-puyo-drop' : ''} ${clearing ? 'animate-puyo-clear' : ''}`}
               >
-                {cv !== null && <div class="puyo-mouth" />}
+                {cv !== null && (
+                  <>
+                    <div class="puyo-eye left" />
+                    <div class="puyo-eye right" />
+                    <div class="puyo-mouth" />
+                  </>
+                )}
               </div>
             );
           })

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -8,12 +8,12 @@ interface Props {
 }
 
 const colors = [
-  'bg-red-500',
-  'bg-blue-500',
-  'bg-green-500',
-  'bg-yellow-400',
+  'puyo-red',
+  'puyo-blue',
+  'puyo-green',
+  'puyo-yellow',
   // index 4: ojama
-  'bg-gray-400'
+  'puyo-ojama'
 ];
 
 const PuyoBoard: Component<Props> = (props) => {

--- a/src/components/PuyoBoard.tsx
+++ b/src/components/PuyoBoard.tsx
@@ -48,9 +48,15 @@ const PuyoBoard: Component<Props> = (props) => {
             const cv = getCell(rowIndex, colIndex);
             return (
               <div
-                style={{ width: `${size}px`, height: `${size}px` }}
-                class={`${cv !== null ? colors[cv] : 'bg-gray-900'} rounded-full border border-gray-900`}
-              />
+                style={{
+                  width: `${size}px`,
+                  height: `${size}px`,
+                  transform: cv !== null ? 'scale(1)' : 'scale(0)',
+                }}
+                class={`${cv !== null ? colors[cv] : 'bg-gray-900'} puyo`}
+              >
+                {cv !== null && <div class="puyo-mouth" />}
+              </div>
             );
           })
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -41,3 +41,40 @@ body {
 .puyo-ojama {
   background: radial-gradient(circle at 30% 30%, #e5e7eb, #9ca3af 40%, #374151);
 }
+
+.puyo {
+  position: relative;
+  border-radius: 9999px;
+  border: 1px solid #111827;
+  transition: transform 0.2s;
+}
+
+.puyo::before,
+.puyo::after {
+  content: '';
+  position: absolute;
+  top: 30%;
+  width: 18%;
+  height: 18%;
+  background: #000;
+  border-radius: 50%;
+}
+
+.puyo::before {
+  left: 25%;
+}
+
+.puyo::after {
+  right: 25%;
+}
+
+.puyo-mouth {
+  position: absolute;
+  bottom: 20%;
+  left: 50%;
+  width: 30%;
+  height: 12%;
+  background: #000;
+  border-radius: 0 0 50% 50%;
+  transform: translateX(-50%);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -79,9 +79,9 @@ body {
   transform: translateX(-50%);
 }
 
-@keyframes puyoFall {
+@keyframes puyoDrop {
   from {
-    transform: translateY(-100%);
+    transform: translateY(var(--startY));
   }
   to {
     transform: translateY(0);
@@ -99,8 +99,8 @@ body {
   }
 }
 
-.animate-puyo-fall {
-  animation: puyoFall 0.2s ease-out;
+.animate-puyo-drop {
+  animation: puyoDrop 0.2s ease-out;
 }
 
 .animate-puyo-clear {

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ body {
   position: relative;
   border-radius: 9999px;
   border: 1px solid #111827;
-  transition: transform 0.2s;
+  transition: transform 0.2s, opacity 0.2s;
 }
 
 .puyo::before,
@@ -77,4 +77,32 @@ body {
   background: #000;
   border-radius: 0 0 50% 50%;
   transform: translateX(-50%);
+}
+
+@keyframes puyoFall {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes puyoClear {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0);
+  }
+}
+
+.animate-puyo-fall {
+  animation: puyoFall 0.2s ease-out;
+}
+
+.animate-puyo-clear {
+  animation: puyoClear 0.2s ease-out forwards;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -20,3 +20,24 @@ body {
   min-width: 320px;
   min-height: 100vh;
 }
+
+/* Puyo Puyo style pieces */
+.puyo-red {
+  background: radial-gradient(circle at 30% 30%, #fee2e2, #f87171 40%, #b91c1c);
+}
+
+.puyo-blue {
+  background: radial-gradient(circle at 30% 30%, #dbeafe, #60a5fa 40%, #1e40af);
+}
+
+.puyo-green {
+  background: radial-gradient(circle at 30% 30%, #dcfce7, #4ade80 40%, #166534);
+}
+
+.puyo-yellow {
+  background: radial-gradient(circle at 30% 30%, #fef9c3, #facc15 40%, #ca8a04);
+}
+
+.puyo-ojama {
+  background: radial-gradient(circle at 30% 30%, #e5e7eb, #9ca3af 40%, #374151);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -49,32 +49,55 @@ body {
   transition: transform 0.2s, opacity 0.2s;
 }
 
-.puyo::before,
-.puyo::after {
+
+.puyo-eye {
+  position: absolute;
+  top: 28%;
+  width: 24%;
+  height: 28%;
+  background: #fff;
+  border-radius: 50%;
+  border: 1px solid #000;
+}
+
+.puyo-eye::after {
   content: '';
   position: absolute;
-  top: 30%;
-  width: 18%;
-  height: 18%;
+  width: 70%;
+  height: 70%;
   background: #000;
   border-radius: 50%;
+  bottom: 10%;
+  left: 15%;
 }
 
-.puyo::before {
-  left: 25%;
+.puyo-eye::before {
+  content: '';
+  position: absolute;
+  width: 30%;
+  height: 30%;
+  background: #fff;
+  border-radius: 50%;
+  top: 20%;
+  left: 20%;
 }
 
-.puyo::after {
-  right: 25%;
+.puyo-eye.left {
+  left: 22%;
+}
+
+.puyo-eye.right {
+  right: 22%;
 }
 
 .puyo-mouth {
   position: absolute;
-  bottom: 20%;
+  bottom: 18%;
   left: 50%;
-  width: 30%;
-  height: 12%;
-  background: #000;
+  width: 26%;
+  height: 16%;
+  border: 2px solid #000;
+  border-top: none;
   border-radius: 0 0 50% 50%;
   transform: translateX(-50%);
 }


### PR DESCRIPTION
## Summary
- make puyo colors use gradient styles to look closer to the real game

## Testing
- `npm run build` *(fails: Cannot find module 'solid-js' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6840b56fc89c8328bf7fadb52dd9624c