### PR TITLE
Apply rotation guard to rotate180

### DIFF
--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -332,6 +332,13 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     const pos = currentPosition();
     if (!cp || !pos || gameOver() || isPaused()) return;
 
+    const now = Date.now();
+    if (isRotating || now - lastRotationTime < 50) return;
+
+    try {
+      isRotating = true;
+      lastRotationTime = now;
+
     const attempts = rotateTetrominoSRS180(cp);
     for (const { piece: newPiece, offset } of attempts) {
       const np = { row: pos.row + offset.row, col: pos.col + offset.col };
@@ -343,6 +350,9 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
       }
     }
     updateGhostPosition();
+    } finally {
+      setTimeout(() => { isRotating = false; }, 50);
+    }
   };
 
   // ハードドロップ（一番下まで一気に落とす）


### PR DESCRIPTION
## Summary
- avoid rapid-fire calls to `rotate180` using the existing `isRotating` guard

## Testing
- `npm run build` *(fails: Cannot find module 'solid-js' due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853a1024e1883288a629f2b3f5f1d54