### PR TITLE
Handle game over when locking piece above board

### DIFF
--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -412,6 +412,9 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
 
     // 頭上でロックされた場合は row=0 扱いで落とす
     const lockStartRow = Math.max(pos.row, 0);
+    if (pos.row < 0) {
+      setGameOver(true);
+    }
 
     const newBoard = [...board()];
     cp.shape.forEach((row: number[], y: number) => {
@@ -440,7 +443,9 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     // 行クリア処理中フラグ
     if (rowsToClear.length === 0) {
       // ライン消去なしなら即座に次のピース
-      getNewPiece();
+      if (!gameOver()) {
+        getNewPiece();
+      }
       return;
     }
     
@@ -469,11 +474,15 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
         onAttack(sent);
         
         // 行削除後に次のピース取得（確実に1回だけ呼ぶ）
-        getNewPiece();
+        if (!gameOver()) {
+          getNewPiece();
+        }
       } catch (e) {
         console.error('Line clearing error:', e);
         // エラー時にもピースを出す
-        getNewPiece();
+        if (!gameOver()) {
+          getNewPiece();
+        }
       }
     }, CLEAR_ANIMATION_DURATION);
   };


### PR DESCRIPTION
## Summary
- trigger game over if a piece locks above the board
- avoid spawning new pieces after line clear when game over

## Testing
- `npm run build` *(fails: Cannot find module 'solid-js' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853a10fc85c83288d61a5c9059f6a7c