### PR TITLE
Fix spawn top-out bug

### DIFF
--- a/src/components/HoldPiece.tsx
+++ b/src/components/HoldPiece.tsx
@@ -1,4 +1,4 @@
-import { Tetromino } from '../models/tetromino.tsx';
+import { Tetromino } from '../models/tetromino';
 
 interface HoldPieceProps {
   piece: Tetromino | null;

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -152,7 +152,7 @@ export const useTetris = (seed?: number, onAttackInitial?: (lines: number) => vo
     
     // 開始位置を設定
     const startPosition = {
-      row: 0,
+      row: -2,
       col: Math.floor((BOARD_WIDTH - next.shape[0].length) / 2)
     };
     setCurrentPosition(startPosition);
@@ -463,7 +463,7 @@ const rotate180 = () => {
     if (currentHold) {
       setCurrentPiece(currentHold);
       const startPosition = {
-        row: 0,
+        row: -2,
         col: Math.floor((BOARD_WIDTH - currentHold.shape[0].length) / 2)
       };
       setCurrentPosition(startPosition);


### PR DESCRIPTION
## Summary
- correct import path in `HoldPiece.tsx`
- spawn pieces slightly above the board
- apply same offset when swapping with hold

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853b31548488328a166135044d8c566